### PR TITLE
Adicionar exemplo do RTC HW-111

### DIFF
--- a/hw111/.gitignore
+++ b/hw111/.gitignore
@@ -1,0 +1,3 @@
+build/
+sdkconfig
+sdkconfig.old

--- a/hw111/.vscode/c_cpp_properties.json
+++ b/hw111/.vscode/c_cpp_properties.json
@@ -1,0 +1,23 @@
+{
+    "configurations": [
+        {
+            "name": "ESP-IDF",
+            "compilerPath": "${config:idf.toolsPathWin}\\tools\\xtensa-esp-elf\\esp-14.2.0_20241119\\xtensa-esp-elf\\bin\\xtensa-esp32-elf-gcc.exe",
+            "compileCommands": "${config:idf.buildPath}/compile_commands.json",
+            "includePath": [
+                "${config:idf.espIdfPath}/components/**",
+                "${config:idf.espIdfPathWin}/components/**",
+                "${workspaceFolder}/**"
+            ],
+            "browse": {
+                "path": [
+                    "${config:idf.espIdfPath}/components",
+                    "${config:idf.espIdfPathWin}/components",
+                    "${workspaceFolder}"
+                ],
+                "limitSymbolsToIncludedHeaders": true
+            }
+        }
+    ],
+    "version": 4
+}

--- a/hw111/.vscode/launch.json
+++ b/hw111/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "gdbtarget",
+      "request": "attach",
+      "name": "Eclipse CDT GDB Adapter"
+    },
+    {
+      "type": "espidf",
+      "name": "Launch",
+      "request": "launch"
+    }
+  ]
+}

--- a/hw111/.vscode/settings.json
+++ b/hw111/.vscode/settings.json
@@ -1,0 +1,17 @@
+{
+    "C_Cpp.intelliSenseEngine": "default",
+    "idf.espIdfPathWin": "C:\\Users\\lordk\\esp\\v5.4\\esp-idf",
+    "idf.pythonInstallPath": "C:\\Users\\lordk\\.espressif\\tools\\idf-python\\3.11.2\\python.exe",
+    "idf.openOcdConfigs": [
+        "board/esp32-wrover-kit-3.3v.cfg"
+    ],
+    "idf.portWin": "COM9",
+    "idf.toolsPathWin": "C:\\Users\\lordk\\.espressif",
+    "idf.flashType": "UART",
+    "github.copilot.enable": {
+        "*": false,
+        "plaintext": false,
+        "markdown": false,
+        "scminput": false
+    }
+}

--- a/hw111/CMakeLists.txt
+++ b/hw111/CMakeLists.txt
@@ -1,0 +1,6 @@
+# The following five lines of boilerplate have to be in your project's
+# CMakeLists in this exact order for cmake to work correctly
+cmake_minimum_required(VERSION 3.5)
+
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+project(hw111)

--- a/hw111/main/CMakeLists.txt
+++ b/hw111/main/CMakeLists.txt
@@ -1,0 +1,2 @@
+idf_component_register(SRCS "main.c"
+                    INCLUDE_DIRS ".")

--- a/hw111/main/main.c
+++ b/hw111/main/main.c
@@ -1,0 +1,77 @@
+#include <stdio.h>
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "driver/i2c.h"
+#include "esp_log.h"
+#include <time.h>
+
+#define I2C_MASTER_NUM      I2C_NUM_0
+#define I2C_MASTER_SDA_IO   19
+#define I2C_MASTER_SCL_IO   18
+#define I2C_MASTER_FREQ_HZ  100000
+#define DS3231_ADDR         0x68
+
+static const char *TAG = "HW111_RTC";
+
+static uint8_t bcd_to_decimal(uint8_t val)
+{
+    return ((val >> 4) * 10) + (val & 0x0F);
+}
+
+static void i2c_master_init(void)
+{
+    i2c_config_t conf = {
+        .mode = I2C_MODE_MASTER,
+        .sda_io_num = I2C_MASTER_SDA_IO,
+        .scl_io_num = I2C_MASTER_SCL_IO,
+        .sda_pullup_en = GPIO_PULLUP_ENABLE,
+        .scl_pullup_en = GPIO_PULLUP_ENABLE,
+        .master.clk_speed = I2C_MASTER_FREQ_HZ,
+    };
+    ESP_ERROR_CHECK(i2c_param_config(I2C_MASTER_NUM, &conf));
+    ESP_ERROR_CHECK(i2c_driver_install(I2C_MASTER_NUM, conf.mode, 0, 0, 0));
+}
+
+static esp_err_t ds3231_read_time(struct tm *timeinfo)
+{
+    uint8_t reg = 0x00;
+    uint8_t data[7];
+    esp_err_t ret = i2c_master_write_read_device(I2C_MASTER_NUM, DS3231_ADDR,
+                                                 &reg, 1, data, sizeof(data),
+                                                 1000 / portTICK_PERIOD_MS);
+    if (ret != ESP_OK) {
+        return ret;
+    }
+
+    timeinfo->tm_sec  = bcd_to_decimal(data[0]);
+    timeinfo->tm_min  = bcd_to_decimal(data[1]);
+    timeinfo->tm_hour = bcd_to_decimal(data[2]);
+    timeinfo->tm_mday = bcd_to_decimal(data[4]);
+    timeinfo->tm_mon  = bcd_to_decimal(data[5] & 0x1F) - 1;
+    timeinfo->tm_year = bcd_to_decimal(data[6]) + 100; // year since 1900
+
+    return ESP_OK;
+}
+
+void app_main(void)
+{
+    i2c_master_init();
+
+    struct tm rtc_time;
+    while (1) {
+        if (ds3231_read_time(&rtc_time) == ESP_OK) {
+            ESP_LOGI(TAG,
+                     "%02d/%02d/%04d %02d:%02d:%02d",
+                     rtc_time.tm_mday,
+                     rtc_time.tm_mon + 1,
+                     rtc_time.tm_year + 1900,
+                     rtc_time.tm_hour,
+                     rtc_time.tm_min,
+                     rtc_time.tm_sec);
+        } else {
+            ESP_LOGE(TAG, "Erro ao ler o RTC");
+        }
+        vTaskDelay(pdMS_TO_TICKS(1000));
+    }
+}
+


### PR DESCRIPTION
## Summary
- adicionar pasta `hw111` com boilerplate do projeto
- incluir `main.c` com exemplo de uso do RTC HW-111 (DS3231)

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684239d82604832ea254817d534ef3ea